### PR TITLE
Add two primitives load-plugin and plugin-lookup

### DIFF
--- a/compiler/primitives.scm
+++ b/compiler/primitives.scm
@@ -137,7 +137,9 @@
     ($restore-stack . 106)
     ($stack? . 107)
     (thread-winders . 108)
-    (thread-winders-set! . 109)))
+    (thread-winders-set! . 109)
+    (load-plugin . 110)
+    (plugin-lookup . 111)))
 
 (define (primitive-number name)
   (let ((v (assq name *primitive-numbers*)))
@@ -499,6 +501,11 @@
 
 (define-call start-cpu-profile "start_cpu_profile" 1)
 (define-call stop-cpu-profile "stop_cpu_profile" 0)
+
+;; Plugin
+
+(define-call load-plugin "load_plugin" 1)
+(define-call plugin-lookup "plugin_lookup" 2)
 
 ;;; A compiler pass
 

--- a/vm/primitives.go
+++ b/vm/primitives.go
@@ -5,9 +5,11 @@ package vm
 import "fmt"
 import "os"
 
-var primitive [110]Obj
+var primitive [112]Obj
 
 func init() {
+	primitive[111] = &Procedure{name: "plugin-lookup", required: 2, apply: nil, label: 111}
+	primitive[110] = &Procedure{name: "load-plugin", required: 1, apply: nil, label: 110}
 	primitive[98] = &Procedure{name: "stop-cpu-profile", required: 0, apply: nil, label: 98}
 	primitive[97] = &Procedure{name: "start-cpu-profile", required: 1, apply: nil, label: 97}
 	primitive[96] = &Procedure{name: "current-thread", required: 0, apply: nil, label: 96}
@@ -122,6 +124,10 @@ func init() {
 
 func evprimn(primop uint32, args []Obj, ct Obj) Obj {
 	switch primop {
+	case 111: // plugin-lookup
+		return plugin_lookup(args[0], args[1])
+	case 110: // load-plugin
+		return load_plugin(args[0])
 	case 98: // stop-cpu-profile
 		return stop_cpu_profile()
 	case 97: // start-cpu-profile

--- a/vm/types.go
+++ b/vm/types.go
@@ -40,6 +40,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"plugin"
 	"sync"
 )
 
@@ -345,6 +346,19 @@ func Symbol_to_string(x Obj) Obj {
 	return ([]rune)(x.(*ScmSym).str)
 }
 
+type Plugin struct {
+	name string
+	*plugin.Plugin
+}
+
+func plugin_p(p Obj) Obj {
+	switch p.(type) {
+	case *Plugin:
+		return true
+	}
+	return false
+}
+
 // Object printer (for debugging)
 
 func Obj_display(x Obj, p io.Writer, write Obj) {
@@ -433,6 +447,9 @@ func Obj_display(x Obj, p io.Writer, write Obj) {
 		t := (x).(*Thread)
 		Obj_display(t.name, p, write)
 		fmt.Fprintf(p, ">")
+	case plugin_p(x) != False:
+		t := (x).(*Plugin)
+		fmt.Fprintf(p, "#<plugin %s>", t.name)
 	// Unknown types
 	default:
 		fmt.Fprintf(p, "#<obj %x>", x)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -27,6 +27,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"plugin"
 	"runtime"
 	"runtime/debug"
 )
@@ -157,6 +158,7 @@ type Procedure struct {
 	name     string
 	required int
 	apply    func(proc *Procedure, args []Obj, ct Obj) Obj
+	plugin   plugin.Symbol
 	label    int
 	free     []Obj
 	code     *Code
@@ -577,6 +579,10 @@ func apply_primitive(proc *Procedure, args []Obj, ct Obj) Obj {
 	// arguments, like e.g. make-string
 	if len(args) < proc.required {
 		panic(fmt.Sprintf("Too few arguments to primitive procedure %s", proc.name))
+	}
+	if proc.plugin != nil {
+		fn := proc.plugin.(func([]Obj) Obj)
+		return fn(args)
 	}
 	return evprimn(uint32(proc.label), args, ct)
 }


### PR DESCRIPTION
Go plugin make conscheme more extensible, avoid rebuilding the binary every time.

```
➜  test cat test.go 
package main

import (
	"fmt"

	"github.com/weinholt/conscheme/vm"
)

func World(args []vm.Obj) vm.Obj {
	fmt.Println("Hello World", string(args[0].([]rune)))
	return vm.Void
}
```

```
➜  test go build -buildmode=plugin -o hello.so test.go
➜  compiler git:(plugin) conscheme 
;; Con Scheme
;; Copyright (C) 2011, 2017 Göran Weinholt <goran@weinholt.se>
;; Copyright (C) 2011 Per Odlund <per.odlund@gmail.com>

#;0> (define plugin (load-plugin "/home/genius/project/test/hello.so"))
#;1> plugin
#<plugin hello.so>
#;2> (define fn (plugin-lookup plugin "World"))
#;3> fn
#<procedure World>
#;4> (fn "xxxx")
Hello World xxxx
#;5> 

```

BTW, is this project still maintained? I find it rather mature (bootstrap is a good sign), but it still can be improved in those direction:

* Interoperation with Go ecosystem
* Better performance

lisp is really good, I'm not keen to scheme language semantics and writing my own lisp.
The VM part is much common, may I contribute to it?
I'd like to see this project been used in the real world rather than just a toy.
Great job, Thank you! @weinholt 
