### PR TITLE
introduce function mustXXX() instead of obj.(XXX) assertion

### DIFF
--- a/vm/arithmetic.go
+++ b/vm/arithmetic.go
@@ -525,7 +525,7 @@ func _number_to_string(num Obj, radix Obj) Obj {
 
 // TODO: handle flonums, compnums, ratnums, etc
 func _string_to_number(_str Obj, _radix Obj) Obj {
-	str := string((_str).([]rune))
+	str := string(mustString(_str))
 
 	radix := number_to_int(_radix)
 	switch {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -70,39 +70,39 @@ func thread_p(thread Obj) Obj {
 }
 
 func thread_name(thread Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	return t.name
 }
 
 func thread_specific(thread Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	return t.specific
 }
 
 func thread_specific_set_ex(thread, v Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	t.specific = v
 	return Void
 }
 
 func thread_queue(thread Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	return t.queue
 }
 
 func thread_queue_set_ex(thread, v Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	t.queue = v
 	return Void
 }
 
 func thread_winders(thread Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	return t.winders
 }
 
 func thread_winders_set_ex(thread, v Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	t.winders = v
 	return Void
 }
@@ -113,13 +113,13 @@ func thread_yield_ex() Obj {
 }
 
 func thread_link_ex(_t1, _t2 Obj) Obj {
-	t1 := (_t1).(*Thread)
+	t1 := mustThread(_t1)
 	t1.links.PushFront(_t2)
 	return Void
 }
 
 func send(thread, o Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	go func(t *Thread, o Obj) {
 		t.channel <- o
 	}(t, o)
@@ -127,18 +127,18 @@ func send(thread, o Obj) Obj {
 }
 
 func _receive(thread Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 	return <-t.channel
 }
 
 func thread_start_ex(thread Obj) Obj {
-	t := (thread).(*Thread)
+	t := mustThread(thread)
 
 	go t.once.Do(func() {
 		defer func() {
 			if err := recover(); err != nil {
 				for e := t.links.Front(); e != nil; e = e.Next() {
-					send((e.Value).(Obj), _vector(intern("died"), thread))
+					send(e.Value, _vector(intern("died"), thread))
 				}
 				return
 			}


### PR DESCRIPTION
Hi, @weinholt 
I plan to refactor the object representation. 
`interface{}` is poor in performance and has problem for `eq?` comparison.

```
type Obj *scmHead
type scmHead int
const (
	Integer    = 0
	Pair       = 1
	Vector     = 2
	Null       = 3
	String     = 4
        ...
)
```

Every scheme object will have scmHead embeded:

```
type ScmPair struct {
     scmHead
     car Obj
     cdr Obj
}

type ScmVector struct {
     scmHead
     []Obj
}
```

And use `unsafe.Pointer` to transform Obj to specific object:

```
func Cons(x, y Obj) Obj {
     tmp := ScmPair{
         scmHead : Pair,
         car : x,
         cdr : y,
     }
     return Obj(&tmp.scmHead)
}
func mustPair(o Obj) *ScmPair {
     return *ScmPair(unsafe.Pointer(o))
}
```

Tagged pointer for fixnum should also be possible, but I'll leave it in the further optimization.
This refactor involves many changes, I have to do it step by step:

+ [x] Provide function to operate Obj, rather than depends on specific Obj implementation (as is done in this PR)
+ [ ] Change some structs representation such as ScmPair, ScmVector ... each has scmHead embeded
+ [ ] Change Obj definition from interface{} to *scmHead
+ [ ] Fix issue https://github.com/weinholt/conscheme/issues/6
